### PR TITLE
Fix front matter and sub-skill references so the skills load

### DIFF
--- a/.codex-marketplace/instagram-skills/skills/ig-audience-insights/SKILL.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-audience-insights/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ig-audience-insights
-description: Read your Instagram niche and profile from real data via Apify, no login. Scan a hashtag for the posts traveling now (likes, comments, owner) to see the format and hook that works. Pull profile stats for any handle, yours or a competitor's: followers, posts, bio, category. Instagram hides who liked or commented on other accounts, so this is discovery plus profiles, not engagers. Triggers on "what works in my niche", "scan the hashtag", "competitor stats". Not for writing captions (use ig-caption-writer).
+description: >-
+  Read your Instagram niche and profile from real data via Apify, no login. Scan a hashtag for the posts traveling now (likes, comments, owner) to see the format and hook that works. Pull profile stats for any handle, yours or a competitor's: followers, posts, bio, category. Instagram hides who liked or commented on other accounts, so this is discovery plus profiles, not engagers. Triggers on "what works in my niche", "scan the hashtag", "competitor stats". Not for writing captions (use ig-caption-writer).
 ---
 
 # Instagram Audience Insights

--- a/.codex-marketplace/instagram-skills/skills/ig-carousel-planner/references/slide-architecture.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-carousel-planner/references/slide-architecture.md
@@ -87,4 +87,4 @@ payoff), not a padded 10.
 
 The caption can be short for a carousel because the slides carry the payload. It
 should: restate the hook for the "more" fold, add one line of context, carry the
-CTA, and hold the 3-5 sized hashtags. See `../../references/hashtag-strategy.md`.
+CTA, and hold the 3-5 sized hashtags. See `../../../references/hashtag-strategy.md`.

--- a/.codex-marketplace/instagram-skills/skills/ig-hashtag-strategist/references/sourcing-tactics.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-hashtag-strategist/references/sourcing-tactics.md
@@ -1,7 +1,7 @@
 # Hashtag Sourcing Tactics
 
 How `ig-hashtag-strategist` finds and sizes candidate tags. Pairs with the full
-model in `../../references/hashtag-strategy.md`.
+model in `../../../references/hashtag-strategy.md`.
 
 ## Finding niche tags (the workhorses)
 

--- a/.codex-marketplace/instagram-skills/skills/ig-hook-extractor/references/classification-rules.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-hook-extractor/references/classification-rules.md
@@ -1,7 +1,7 @@
 # Hook Classification Rules (Instagram)
 
 Feature extraction and scoring heuristics `ig-hook-extractor` uses to map a post
-to one of the 10 formulas in `../../references/hook-formulas.md`.
+to one of the 10 formulas in `../../../references/hook-formulas.md`.
 
 ## Step 1: detect the surface
 

--- a/.codex-marketplace/instagram-skills/skills/ig-humanizer/sub-skills/illustration.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-humanizer/sub-skills/illustration.md
@@ -28,7 +28,7 @@ agent (Claude Code, Codex, OpenClaw).
 2. **Craft the prompt.** Describe subject, composition, style, palette. Default
    to a clean professional look unless Voice & Brand Profile §6 sets a visual
    style. Do NOT bake the post's words into the art (use overlay).
-3. **Apply brand overlay (if profile has it).** Read `../../references/voice-profile.md`
+3. **Apply brand overlay (if profile has it).** Read `../../../references/voice-profile.md`
    §6. If a handle, brand color, or logo is set, pass an `overlay` so text/logo is
    composited pixel-exact (crisp even on a cheap model):
    ```python

--- a/.codex-marketplace/instagram-skills/skills/ig-humanizer/sub-skills/voice-profile.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-humanizer/sub-skills/voice-profile.md
@@ -1,6 +1,6 @@
 # Sub-skill: Build / update the Voice & Brand Profile
 
-Builds or refreshes `../../references/voice-profile.md` so every writing skill in
+Builds or refreshes `../../../references/voice-profile.md` so every writing skill in
 this bundle drafts in the user's real voice instead of a generic "human" voice.
 Runs on any agent (Claude Code, Codex, OpenClaw): the core path needs only the
 user's own writing pasted in. A read token (Apify) is an optional accelerator,
@@ -28,7 +28,7 @@ never required.
    avoid, emoji/hashtag behavior.
 3. Infer niche, ICP, and pillars from the sample topics; confirm rather than guess.
 4. Capture hard rules and CTA/link style the samples reveal or the user states.
-5. Write `../../references/voice-profile.md`: fill sections 1-5, copy the 2-4
+5. Write `../../../references/voice-profile.md`: fill sections 1-5, copy the 2-4
    strongest lines verbatim into "Signature examples", and set the Status block to
    `filled: yes`, `source: <pasted|read-layer|manual>`, `updated: <today>`.
 6. Show the filled profile for approval before saving; tell the user every writing

--- a/.codex-marketplace/instagram-skills/skills/ig-profile-optimizer/SKILL.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-profile-optimizer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ig-profile-optimizer
-description: Audit and rewrite an Instagram profile end-to-end for 2026: profile photo, searchable NAME field weighted with a keyword, @handle, bio (150 chars: value plus topic plus proof), goal-matched link, category label, story highlights, the first-9 grid, and up to 3 pinned posts. Triggers on "review my Instagram profile", "fix my bio", "optimize highlights", "profile audit". The whole follow decision happens on the profile header. Not for writing captions (use ig-caption-writer).
+description: >-
+  Audit and rewrite an Instagram profile end-to-end for 2026: profile photo, searchable NAME field weighted with a keyword, @handle, bio (150 chars: value plus topic plus proof), goal-matched link, category label, story highlights, the first-9 grid, and up to 3 pinned posts. Triggers on "review my Instagram profile", "fix my bio", "optimize highlights", "profile audit". The whole follow decision happens on the profile header. Not for writing captions (use ig-caption-writer).
 ---
 
 # Instagram Profile Optimizer

--- a/.codex-marketplace/instagram-skills/skills/ig-repurposer/SKILL.md
+++ b/.codex-marketplace/instagram-skills/skills/ig-repurposer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ig-repurposer
-description: Repurpose existing content into a native Instagram post. Take a LinkedIn, blog, YouTube script, or X tweet or thread and rebuild it for Instagram: a long piece becomes a carousel or a caption, re-hooked before the 125-char fold, off-platform artifacts stripped (X @-handles, link in bio), published via Publora on approval. Use to adapt content across platforms into Instagram. Not for writing from scratch (use ig-caption-writer or ig-carousel-planner), not for auditing a draft (ig-humanizer --mode audit).
+description: >-
+  Repurpose existing content into a native Instagram post. Take a LinkedIn, blog, YouTube script, or X tweet or thread and rebuild it for Instagram: a long piece becomes a carousel or a caption, re-hooked before the 125-char fold, off-platform artifacts stripped (X @-handles, link in bio), published via Publora on approval. Use to adapt content across platforms into Instagram. Not for writing from scratch (use ig-caption-writer or ig-carousel-planner), not for auditing a draft (ig-humanizer --mode audit).
 ---
 
 # Instagram Repurposer

--- a/skills/ig-audience-insights/SKILL.md
+++ b/skills/ig-audience-insights/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ig-audience-insights
-description: Read your Instagram niche and profile from real data via Apify, no login. Scan a hashtag for the posts traveling now (likes, comments, owner) to see the format and hook that works. Pull profile stats for any handle, yours or a competitor's: followers, posts, bio, category. Instagram hides who liked or commented on other accounts, so this is discovery plus profiles, not engagers. Triggers on "what works in my niche", "scan the hashtag", "competitor stats". Not for writing captions (use ig-caption-writer).
+description: >-
+  Read your Instagram niche and profile from real data via Apify, no login. Scan a hashtag for the posts traveling now (likes, comments, owner) to see the format and hook that works. Pull profile stats for any handle, yours or a competitor's: followers, posts, bio, category. Instagram hides who liked or commented on other accounts, so this is discovery plus profiles, not engagers. Triggers on "what works in my niche", "scan the hashtag", "competitor stats". Not for writing captions (use ig-caption-writer).
 ---
 
 # Instagram Audience Insights

--- a/skills/ig-carousel-planner/references/slide-architecture.md
+++ b/skills/ig-carousel-planner/references/slide-architecture.md
@@ -87,4 +87,4 @@ payoff), not a padded 10.
 
 The caption can be short for a carousel because the slides carry the payload. It
 should: restate the hook for the "more" fold, add one line of context, carry the
-CTA, and hold the 3-5 sized hashtags. See `../../references/hashtag-strategy.md`.
+CTA, and hold the 3-5 sized hashtags. See `../../../references/hashtag-strategy.md`.

--- a/skills/ig-hashtag-strategist/references/sourcing-tactics.md
+++ b/skills/ig-hashtag-strategist/references/sourcing-tactics.md
@@ -1,7 +1,7 @@
 # Hashtag Sourcing Tactics
 
 How `ig-hashtag-strategist` finds and sizes candidate tags. Pairs with the full
-model in `../../references/hashtag-strategy.md`.
+model in `../../../references/hashtag-strategy.md`.
 
 ## Finding niche tags (the workhorses)
 

--- a/skills/ig-hook-extractor/references/classification-rules.md
+++ b/skills/ig-hook-extractor/references/classification-rules.md
@@ -1,7 +1,7 @@
 # Hook Classification Rules (Instagram)
 
 Feature extraction and scoring heuristics `ig-hook-extractor` uses to map a post
-to one of the 10 formulas in `../../references/hook-formulas.md`.
+to one of the 10 formulas in `../../../references/hook-formulas.md`.
 
 ## Step 1: detect the surface
 

--- a/skills/ig-humanizer/sub-skills/illustration.md
+++ b/skills/ig-humanizer/sub-skills/illustration.md
@@ -28,7 +28,7 @@ agent (Claude Code, Codex, OpenClaw).
 2. **Craft the prompt.** Describe subject, composition, style, palette. Default
    to a clean professional look unless Voice & Brand Profile §6 sets a visual
    style. Do NOT bake the post's words into the art (use overlay).
-3. **Apply brand overlay (if profile has it).** Read `../../references/voice-profile.md`
+3. **Apply brand overlay (if profile has it).** Read `../../../references/voice-profile.md`
    §6. If a handle, brand color, or logo is set, pass an `overlay` so text/logo is
    composited pixel-exact (crisp even on a cheap model):
    ```python

--- a/skills/ig-humanizer/sub-skills/voice-profile.md
+++ b/skills/ig-humanizer/sub-skills/voice-profile.md
@@ -1,6 +1,6 @@
 # Sub-skill: Build / update the Voice & Brand Profile
 
-Builds or refreshes `../../references/voice-profile.md` so every writing skill in
+Builds or refreshes `../../../references/voice-profile.md` so every writing skill in
 this bundle drafts in the user's real voice instead of a generic "human" voice.
 Runs on any agent (Claude Code, Codex, OpenClaw): the core path needs only the
 user's own writing pasted in. A read token (Apify) is an optional accelerator,
@@ -28,7 +28,7 @@ never required.
    avoid, emoji/hashtag behavior.
 3. Infer niche, ICP, and pillars from the sample topics; confirm rather than guess.
 4. Capture hard rules and CTA/link style the samples reveal or the user states.
-5. Write `../../references/voice-profile.md`: fill sections 1-5, copy the 2-4
+5. Write `../../../references/voice-profile.md`: fill sections 1-5, copy the 2-4
    strongest lines verbatim into "Signature examples", and set the Status block to
    `filled: yes`, `source: <pasted|read-layer|manual>`, `updated: <today>`.
 6. Show the filled profile for approval before saving; tell the user every writing

--- a/skills/ig-profile-optimizer/SKILL.md
+++ b/skills/ig-profile-optimizer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ig-profile-optimizer
-description: Audit and rewrite an Instagram profile end-to-end for 2026: profile photo, searchable NAME field weighted with a keyword, @handle, bio (150 chars: value plus topic plus proof), goal-matched link, category label, story highlights, the first-9 grid, and up to 3 pinned posts. Triggers on "review my Instagram profile", "fix my bio", "optimize highlights", "profile audit". The whole follow decision happens on the profile header. Not for writing captions (use ig-caption-writer).
+description: >-
+  Audit and rewrite an Instagram profile end-to-end for 2026: profile photo, searchable NAME field weighted with a keyword, @handle, bio (150 chars: value plus topic plus proof), goal-matched link, category label, story highlights, the first-9 grid, and up to 3 pinned posts. Triggers on "review my Instagram profile", "fix my bio", "optimize highlights", "profile audit". The whole follow decision happens on the profile header. Not for writing captions (use ig-caption-writer).
 ---
 
 # Instagram Profile Optimizer

--- a/skills/ig-repurposer/SKILL.md
+++ b/skills/ig-repurposer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ig-repurposer
-description: Repurpose existing content into a native Instagram post. Take a LinkedIn, blog, YouTube script, or X tweet or thread and rebuild it for Instagram: a long piece becomes a carousel or a caption, re-hooked before the 125-char fold, off-platform artifacts stripped (X @-handles, link in bio), published via Publora on approval. Use to adapt content across platforms into Instagram. Not for writing from scratch (use ig-caption-writer or ig-carousel-planner), not for auditing a draft (ig-humanizer --mode audit).
+description: >-
+  Repurpose existing content into a native Instagram post. Take a LinkedIn, blog, YouTube script, or X tweet or thread and rebuild it for Instagram: a long piece becomes a carousel or a caption, re-hooked before the 125-char fold, off-platform artifacts stripped (X @-handles, link in bio), published via Publora on approval. Use to adapt content across platforms into Instagram. Not for writing from scratch (use ig-caption-writer or ig-carousel-planner), not for auditing a draft (ig-humanizer --mode audit).
 ---
 
 # Instagram Repurposer


### PR DESCRIPTION
Two things that stop this package working after a fresh install. Both are
verified against `main` as of today, and neither changes any wording.

## 1. Front matter that does not parse

Claude Code reads the front matter of each `SKILL.md` as YAML. In several of
them it raises, and the skill then never appears in a session - no error
message, nothing missing from the plugin list, just a skill that is not there.

Two causes:

- an unquoted scalar containing `": "`, which YAML reads as the start of a
  nested mapping
- a single-quoted scalar with an unescaped apostrophe, which closes the string
  early

Both fixed by moving `description` to a folded block scalar (`>-`), which needs
no escaping at all. Each description was compared character for character after
the edit, so the text is byte-identical.

Checked with `yaml.safe_load` over every `SKILL.md` in the repo: they all parse
now, and each has a `name` and a `description`.

## 2. Sub-skill references one level short

A file under `skills/<name>/sub-skills/` or `skills/<name>/references/` sits one
directory deeper than `SKILL.md`, so the shared `references/` at the repo root
is `../../../references/` from there rather than `../../`. Every one of these was
short by one level and did not resolve.

Only paths that fail today and start resolving with one more `../` were touched.
Correct ones were left alone, and so was `../../references/X.md` in `CLAUDE.md`
and `AGENTS.md` - that one is a placeholder in prose, not a link.

The `.codex-marketplace/` copies carry the same files and are fixed alongside,
so the two trees do not drift.